### PR TITLE
Fix deprecation warning for collections

### DIFF
--- a/flask_nav/__init__.py
+++ b/flask_nav/__init__.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from importlib import import_module
 import re
 
@@ -46,7 +46,7 @@ class NavbarRenderingError(Exception):
     pass
 
 
-class ElementRegistry(collections.MutableMapping):
+class ElementRegistry(collections.abc.MutableMapping):
     def __init__(self):
         self._elems = {}
 


### PR DESCRIPTION
Resolves this error

```
flask_nav\__init__.py:49: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class ElementRegistry(collections.MutableMapping):
```

Edit: Fixes #28