### PR TITLE
MutableMapping moved, update __init__.py

### DIFF
--- a/flask_nav/__init__.py
+++ b/flask_nav/__init__.py
@@ -46,7 +46,7 @@ class NavbarRenderingError(Exception):
     pass
 
 
-class ElementRegistry(collections.MutableMapping):
+class ElementRegistry(collections.abc.MutableMapping):
     def __init__(self):
         self._elems = {}
 


### PR DESCRIPTION
The attribute MutableMapping from the module collections got moved into collections.abc in python3.10.

If we don't make this update, users will see this error when they try to use this package: https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping.